### PR TITLE
PREX-17116: [W53][Prod][Biometric] Biometric settings toggle does not respond

### DIFF
--- a/WebAuthnKit/Sources/Authenticator/Internal/KeySupport.swift
+++ b/WebAuthnKit/Sources/Authenticator/Internal/KeySupport.swift
@@ -54,7 +54,7 @@ public class ECDSAKeySupport : KeySupport {
         )
         let privateAccessControl = EllipticCurveKeyPair.AccessControl(
             protection: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
-            flags:      [.userPresence, .privateKeyUsage]
+            flags:      [.privateKeyUsage]
         )
         let config = EllipticCurveKeyPair.Config(
             publicLabel:             "\(label)/public",


### PR DESCRIPTION
Resolves: https://prex.atlassian.net/browse/PREX-17116

Removes `.userPresence` to fix the issue where generating a key pair would fail on a device that only has Passcode after restarting the device.  