### PR TITLE
PI-946: Display error code to the user

### DIFF
--- a/WebAuthnKit/Sources/Authenticator/Internal/KeySupport.swift
+++ b/WebAuthnKit/Sources/Authenticator/Internal/KeySupport.swift
@@ -13,7 +13,7 @@ import LocalAuthentication
 
 public protocol KeySupport {
     var selectedAlg: COSEAlgorithmIdentifier { get }
-    func createKeyPair(label: String) -> Optional<COSEKey>
+    func createKeyPair(label: String) -> Result<COSEKey, Error>
     func sign(data: [UInt8], label: String, context: LAContext) -> Optional<[UInt8]>
 }
 
@@ -54,7 +54,7 @@ public class ECDSAKeySupport : KeySupport {
         )
         let privateAccessControl = EllipticCurveKeyPair.AccessControl(
             protection: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
-            flags:      [.userPresence]
+            flags:      []
         )
         let config = EllipticCurveKeyPair.Config(
             publicLabel:             "\(label)/public",
@@ -78,14 +78,14 @@ public class ECDSAKeySupport : KeySupport {
         }
     }
     
-    public func createKeyPair(label: String) -> Optional<COSEKey> {
+    public func createKeyPair(label: String) -> Result<COSEKey, Error> {
         WAKLogger.debug("<ECDSAKeySupport> createKeyPair")
         do {
             let pair = self.createPair(label: label)
             let publicKey = try pair.publicKey().data().DER.bytes
             if publicKey.count != 91 {
                 WAKLogger.debug("<ECDSAKeySupport> length of pubKey should be 91: \(publicKey.count)")
-                return nil
+                return .failure(WAKError.unknown)
             }
             
             let x = Array(publicKey[27..<59])
@@ -97,11 +97,11 @@ public class ECDSAKeySupport : KeySupport {
                 xCoord: x,
                 yCoord: y
             )
-            return key
+            return .success(key)
             
         } catch let error {
             WAKLogger.debug("<ECDSAKeySupport> failed to create key-pair: \(error)")
-            return nil
+            return .failure(error)
         }
     }
 }

--- a/WebAuthnKit/Sources/Authenticator/Internal/Session/InternalAuthenticatorMakeCredentialSession.swift
+++ b/WebAuthnKit/Sources/Authenticator/Internal/Session/InternalAuthenticatorMakeCredentialSession.swift
@@ -193,8 +193,14 @@ public class InternalAuthenticatorMakeCredentialSession : AuthenticatorMakeCrede
 
             // TODO should remove fron KeyPair too?
 
-            guard let publicKeyCOSE = keySupport.createKeyPair(label: credSource.keyLabel) else {
-                self.stop(by: .unknown)
+            let publicKeyCOSEResult = keySupport.createKeyPair(label: credSource.keyLabel)
+            guard case let .success(publicKeyCOSE) = publicKeyCOSEResult else {
+                if case let .failure(keyError) = publicKeyCOSEResult {
+                    self.stop(by: .keyPair(keyError.localizedDescription))
+                }
+                else {
+                    self.stop(by: .unknown)
+                }
                 return
             }
 

--- a/WebAuthnKit/Sources/WAKTypes.swift
+++ b/WebAuthnKit/Sources/WAKTypes.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum WAKError : Error {
+public enum WAKError : Error, Equatable {
     case badData
     case badOperation
     case invalidState
@@ -17,7 +17,35 @@ public enum WAKError : Error {
     case timeout
     case notAllowed
     case unsupported
+    case keyPair(String)
     case unknown
+}
+
+extension WAKError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .badData:
+            return "Bad data"
+        case .badOperation:
+            return "Bad operation"
+        case .invalidState:
+            return "Invalid state"
+        case .constraint:
+            return "Constraint"
+        case .cancelled:
+            return "Cancelled"
+        case .timeout:
+            return "Timeout"
+        case .notAllowed:
+            return "Not allowed"
+        case .unsupported:
+            return "Unsupported"
+        case let .keyPair(description):
+            return description
+        case .unknown:
+            return "Unknown"
+        }
+    }
 }
 
 public enum WAKResult<T, Error: Swift.Error> {


### PR DESCRIPTION
Resolves: https://prex.atlassian.net/browse/PI-946

If the WAKError is due to an error when setting up the key pair, then send the error description as well. Also relaxes the `userPresence` requirement for creating the key pair. 