### PR TITLE
PI-978: Define explicit error enum types in 3rd party biometric library

### DIFF
--- a/WebAuthnKit/Sources/Authenticator/Internal/KeySupport.swift
+++ b/WebAuthnKit/Sources/Authenticator/Internal/KeySupport.swift
@@ -85,7 +85,7 @@ public class ECDSAKeySupport : KeySupport {
             let publicKey = try pair.publicKey().data().DER.bytes
             if publicKey.count != 91 {
                 WAKLogger.debug("<ECDSAKeySupport> length of pubKey should be 91: \(publicKey.count)")
-                return .failure(WAKError.other(11))
+                return .failure(WAKError.other(.keyPairLength))
             }
             
             let x = Array(publicKey[27..<59])

--- a/WebAuthnKit/Sources/Authenticator/Internal/Session/InternalAuthenticatorGetAssertionSession.swift
+++ b/WebAuthnKit/Sources/Authenticator/Internal/Session/InternalAuthenticatorGetAssertionSession.swift
@@ -145,7 +145,7 @@ public class InternalAuthenticatorGetAssertionSession : AuthenticatorGetAssertio
             copiedCred.signCount = cred.signCount + self.setting.counterStep
             newSignCount = copiedCred.signCount
             if !self.credentialStore.saveCredentialSource(copiedCred) {
-                self.stop(by: .other(1))
+                self.stop(by: .other(.assertionSaveCredentialSource))
                 return
             }
 
@@ -179,7 +179,7 @@ public class InternalAuthenticatorGetAssertionSession : AuthenticatorGetAssertio
             }
             
             guard let signature = keySupport.sign(data: data, label: cred.keyLabel, context: self.context) else {
-                self.stop(by: .other(2))
+                self.stop(by: .other(.keySupportSign))
                 return
             }
 
@@ -204,7 +204,7 @@ public class InternalAuthenticatorGetAssertionSession : AuthenticatorGetAssertio
             if let err = error as? WAKError {
                 self.stop(by: err)
             } else {
-                self.stop(by: .other(3))
+                self.stop(by: .other(.otherAssertion))
             }
         }
         

--- a/WebAuthnKit/Sources/Authenticator/Internal/Session/InternalAuthenticatorMakeCredentialSession.swift
+++ b/WebAuthnKit/Sources/Authenticator/Internal/Session/InternalAuthenticatorMakeCredentialSession.swift
@@ -151,7 +151,7 @@ public class InternalAuthenticatorMakeCredentialSession : AuthenticatorMakeCrede
                     self.stop(by: .notAllowed)
                     return
                 default:
-                    self.stop(by: .other(4))
+                    self.stop(by: .other(.otherMakeAsk))
                     return
                 }
             }
@@ -199,7 +199,7 @@ public class InternalAuthenticatorMakeCredentialSession : AuthenticatorMakeCrede
                     self.stop(by: .keyPair(keyError.localizedDescription))
                 }
                 else {
-                    self.stop(by: .other(5))
+                    self.stop(by: .keyPair("keyPair not failure"))
                 }
                 return
             }
@@ -208,7 +208,7 @@ public class InternalAuthenticatorMakeCredentialSession : AuthenticatorMakeCrede
 
             if !self.credentialStore.saveCredentialSource(credSource) {
                 WAKLogger.debug("<MakeCredentialSession> failed to save credential source, stop session")
-                self.stop(by: .other(6))
+                self.stop(by: .other(.makeSaveCredentialSource))
                 return
             }
 
@@ -239,7 +239,7 @@ public class InternalAuthenticatorMakeCredentialSession : AuthenticatorMakeCrede
                     context:        self.context
                 ) else {
                     WAKLogger.debug("<MakeCredentialSession> failed to build attestation object")
-                    self.stop(by: .other(7))
+                    self.stop(by: .other(.createAttestation))
                     return
             }
 
@@ -253,7 +253,7 @@ public class InternalAuthenticatorMakeCredentialSession : AuthenticatorMakeCrede
             if let err = error as? WAKError {
                 self.stop(by: err)
             } else {
-                self.stop(by: .other(8))
+                self.stop(by: .other(.otherMakeCredential))
             }
         }
     }

--- a/WebAuthnKit/Sources/Authenticator/Internal/UI/UserConsentUI.swift
+++ b/WebAuthnKit/Sources/Authenticator/Internal/UI/UserConsentUI.swift
@@ -301,12 +301,12 @@ public class UserConsentUI: UserConsentViewControllerDelegate {
                                                 self.dispatchError(resolver, .notAllowed)
                                             default:
                                                 WAKLogger.debug("<UserConsentUI> must not come here")
-                                                self.dispatchError(resolver, .other(9))
+                                                self.dispatchError(resolver, .other(.laError))
                                             }
 
                                         } else {
                                             WAKLogger.debug("<UserConsentUI> must not come here")
-                                            self.dispatchError(resolver, .other(10))
+                                            self.dispatchError(resolver, .other(.otherLAError))
                                         }
                     })
                 } else {

--- a/WebAuthnKit/Sources/Client/Operation/ClientCreateOperation.swift
+++ b/WebAuthnKit/Sources/Client/Operation/ClientCreateOperation.swift
@@ -278,7 +278,7 @@ public class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
         guard let attestedCred =
             attestation.authData.attestedCredentialData else {
             WAKLogger.debug("<CreateOperation> attested credential data not found")
-            self.dispatchError(.other(12))
+            self.dispatchError(.other(.credentialDataNotFound))
             return
         }
 
@@ -295,7 +295,7 @@ public class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
             atts = attestation.toNone()
             guard let bytes = atts.toBytes() else {
                 WAKLogger.debug("<CreateOperation> failed to build attestation-object")
-                self.dispatchError(.other(13))
+                self.dispatchError(.other(.failedBuildAttestationNone))
                 return
             }
             attestationObject = bytes
@@ -306,7 +306,7 @@ public class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
         } else {
             guard let bytes = atts.toBytes() else {
                 WAKLogger.debug("<CreateOperation> failed to build attestation-object")
-                self.dispatchError(.other(14))
+                self.dispatchError(.other(.failedBuildAttestation))
                 return
             }
             attestationObject = bytes

--- a/WebAuthnKit/Sources/Client/Operation/ClientGetOperation.swift
+++ b/WebAuthnKit/Sources/Client/Operation/ClientGetOperation.swift
@@ -282,7 +282,7 @@ public class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
             WAKLogger.debug("<GetOperation> use credentialId from authenticator")
             guard let resultId = assertion.credentailId else {
                 WAKLogger.debug("<GetOperation> credentialId not found")
-                self.dispatchError(.other(15))
+                self.dispatchError(.other(.discoverCredentialNotFound))
                 return
             }
             credentialId = resultId

--- a/WebAuthnKit/Sources/WAKTypes.swift
+++ b/WebAuthnKit/Sources/WAKTypes.swift
@@ -18,8 +18,23 @@ public enum WAKError : Error, Equatable {
     case notAllowed
     case unsupported
     case keyPair(String)
-    case unknown
-    case other(Int)
+    case other(WAKOther)
+    public enum WAKOther: String, Equatable {
+        case assertionSaveCredentialSource
+        case keySupportSign
+        case otherAssertion
+        case otherMakeAsk
+        case makeSaveCredentialSource
+        case createAttestation
+        case otherMakeCredential
+        case laError
+        case otherLAError
+        case keyPairLength
+        case credentialDataNotFound
+        case failedBuildAttestationNone
+        case failedBuildAttestation
+        case discoverCredentialNotFound
+    }
 }
 
 extension WAKError: LocalizedError {
@@ -42,11 +57,9 @@ extension WAKError: LocalizedError {
         case .unsupported:
             return "Unsupported"
         case let .keyPair(description):
-            return description
-        case .unknown:
-            return "Unknown"
+            return "keyPair \(description)"
         case let .other(code):
-            return String(code)
+            return code.rawValue
         }
     }
 }


### PR DESCRIPTION
Resolves: https://prex.atlassian.net/browse/PI-978

Uses explicit enum type for other errors and removes the unknown error. 