### PR TITLE
PREX-16766: [Biometric] Unexpected error every time (internal feedback)

### DIFF
--- a/WebAuthnKit/Sources/Authenticator/Internal/KeySupport.swift
+++ b/WebAuthnKit/Sources/Authenticator/Internal/KeySupport.swift
@@ -82,6 +82,7 @@ public class ECDSAKeySupport : KeySupport {
         WAKLogger.debug("<ECDSAKeySupport> createKeyPair")
         do {
             let pair = self.createPair(label: label)
+            try pair.deleteKeyPair()
             let publicKey = try pair.publicKey().data().DER.bytes
             if publicKey.count != 91 {
                 WAKLogger.debug("<ECDSAKeySupport> length of pubKey should be 91: \(publicKey.count)")


### PR DESCRIPTION
Resolves: https://prex.atlassian.net/browse/PREX-16766

The original issue on v1.36 was that the `flags` on `privateAccessControl` should be empty, and that has been resolved by a previous commit https://github.com/teamprex/prex-ios-web-authn-kit-ios/pull/3. Now the issue discovered is that the saved key persists until the iPhone is erased, which would cause the feature to keep failing for any user who attempted to enable biometric authorization on v1.36 and then tried later. So the fix here is to delete the old key when creating/registering a new key.

Cases tested on iPhone XR iOS 16.6:

- [x] Erase device, setup with Face ID (and alphanumeric passcode and iCloud), use on v1.36, then update to use this fix
- [x] Erase device, setup with Face ID (and alphanumeric passcode and iCloud), use this fix, then disable Face ID and try again
- [x] Erase device, setup with 4 digit passcode (and no iCloud), use on v1.36 then update to use this fix
- [x] Erase device, setup with 4 digit passcode (and no iCloud), use this fix, then enabled Face ID and try again