### PR TITLE
PI-7741: Fix `teamprex/prex-ios-web-authn-kit-ios` build on Xcode 26.

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,40 @@
+{
+  "pins" : [
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
+        "version" : "1.9.0"
+      }
+    },
+    {
+      "identity" : "ellipticcurvekeypair",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/agens-no/EllipticCurveKeyPair.git",
+      "state" : {
+        "revision" : "23c10206e15cf3276f25fad0b52cd5b16c9c6537"
+      }
+    },
+    {
+      "identity" : "keychainaccess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/teamprex/KeychainAccess.git",
+      "state" : {
+        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
+        "version" : "4.2.2"
+      }
+    },
+    {
+      "identity" : "promisekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/PromiseKit.git",
+      "state" : {
+        "revision" : "2bc44395edb4f8391902a9ff7c220471882a4d07",
+        "version" : "8.2.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -12,10 +12,10 @@ let package = Package(
             targets: ["WebAuthnKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/mxcl/PromiseKit.git", exact: "6.13.1"),
+        .package(url: "https://github.com/mxcl/PromiseKit.git", exact: "8.2.0"),
         .package(url: "https://github.com/agens-no/EllipticCurveKeyPair.git", revision: "23c10206e15cf3276f25fad0b52cd5b16c9c6537"),
         .package(url: "https://github.com/teamprex/KeychainAccess.git", exact: "4.2.2"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.3.8"),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.9.0"),
     ],
     targets: [
         .target(

--- a/WebAuthnKit/Sources/Authenticator/Authenticator.swift
+++ b/WebAuthnKit/Sources/Authenticator/Authenticator.swift
@@ -20,14 +20,14 @@ public struct AuthenticatorAssertionResult {
     }
 }
 
-public protocol AuthenticatorMakeCredentialSessionDelegate: class {
+public protocol AuthenticatorMakeCredentialSessionDelegate: AnyObject {
     func authenticatorSessionDidBecomeAvailable(session: AuthenticatorMakeCredentialSession)
     func authenticatorSessionDidBecomeUnavailable(session: AuthenticatorMakeCredentialSession)
     func authenticatorSessionDidStopOperation(session: AuthenticatorMakeCredentialSession, reason: WAKError)
     func authenticatorSessionDidMakeCredential(session: AuthenticatorMakeCredentialSession, attestation: AttestationObject)
 }
 
-public protocol AuthenticatorGetAssertionSessionDelegate: class {
+public protocol AuthenticatorGetAssertionSessionDelegate: AnyObject {
     func authenticatorSessionDidBecomeAvailable(session: AuthenticatorGetAssertionSession)
     func authenticatorSessionDidBecomeUnavailable(session: AuthenticatorGetAssertionSession)
     func authenticatorSessionDidStopOperation(session: AuthenticatorGetAssertionSession, reason: WAKError)

--- a/WebAuthnKit/Sources/Authenticator/Internal/CredentialStore.swift
+++ b/WebAuthnKit/Sources/Authenticator/Internal/CredentialStore.swift
@@ -30,7 +30,7 @@ public class KeychainCredentialStore : CredentialStore {
         let keychain = Keychain(service: rpId)
         return keychain.allKeys().compactMap {
                 if let result = try? keychain.getData($0) {
-                    let bytes = result.bytes
+                    let bytes = result.byteArray
                     return PublicKeyCredentialSource.fromCBOR(bytes)
                 } else {
                     WAKLogger.debug("<KeychainStore> failed to load data for key:\($0)")
@@ -58,7 +58,7 @@ public class KeychainCredentialStore : CredentialStore {
             let keychain = Keychain(service: rpId)
 
             if let result = try? keychain.getData(handle) {
-                let bytes = result.bytes
+                let bytes = result.byteArray
                 return PublicKeyCredentialSource.fromCBOR(bytes)
             } else {
                 WAKLogger.debug("<KeychainStore> failed to load data for key:\(handle)")
@@ -91,7 +91,7 @@ public class KeychainCredentialStore : CredentialStore {
 
         if let bytes = cred.toCBOR() {
             do {
-                try keychain.set(Data(bytes: bytes), key: handle)
+                try keychain.set(Data(bytes), key: handle)
                 return true
             } catch let error {
                 WAKLogger.debug("<KeychainStore> failed to save credential-source: \(error)")

--- a/WebAuthnKit/Sources/Authenticator/Internal/KeySupport.swift
+++ b/WebAuthnKit/Sources/Authenticator/Internal/KeySupport.swift
@@ -70,8 +70,8 @@ public class ECDSAKeySupport : KeySupport {
     public func sign(data: [UInt8], label: String, context: LAContext) -> Optional<[UInt8]> {
         do {
             let pair = self.createPair(label: label)
-            let signature = try pair.sign(Data(bytes: data), hash: .sha256, context: context)
-            return signature.bytes
+            let signature = try pair.sign(Data(data), hash: .sha256, context: context)
+            return signature.byteArray
         } catch let error {
             WAKLogger.debug("<ECDSAKeySupport> failed to sign: \(error)")
             return nil
@@ -83,7 +83,7 @@ public class ECDSAKeySupport : KeySupport {
         do {
             let pair = self.createPair(label: label)
             try pair.deleteKeyPair()
-            let publicKey = try pair.publicKey().data().DER.bytes
+            let publicKey = try pair.publicKey().data().DER.byteArray
             if publicKey.count != 91 {
                 WAKLogger.debug("<ECDSAKeySupport> length of pubKey should be 91: \(publicKey.count)")
                 return .failure(WAKError.other(.keyPairLength))

--- a/WebAuthnKit/Sources/Authenticator/Internal/UI/KeyRegistrationViewController.swift
+++ b/WebAuthnKit/Sources/Authenticator/Internal/UI/KeyRegistrationViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import PromiseKit
 
-public protocol KeyDetailViewDelegate: class {
+public protocol KeyDetailViewDelegate: AnyObject {
     func userDidRequestToCreateNewKey(keyName: String)
     func userDidCancel()
 }

--- a/WebAuthnKit/Sources/Authenticator/Internal/UI/KeySelectionViewController.swift
+++ b/WebAuthnKit/Sources/Authenticator/Internal/UI/KeySelectionViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import PromiseKit
 
-public protocol KeySelectionViewDelegate: class {
+public protocol KeySelectionViewDelegate: AnyObject {
     func userDidSelectCredential(source: PublicKeyCredentialSource)
     func userDidCancel()
 }

--- a/WebAuthnKit/Sources/Authenticator/Internal/UI/UserConsentUI.swift
+++ b/WebAuthnKit/Sources/Authenticator/Internal/UI/UserConsentUI.swift
@@ -13,7 +13,7 @@ import PromiseKit
 import CryptoSwift
 import UIKit
 
-public protocol UserConsentViewControllerDelegate: class {
+public protocol UserConsentViewControllerDelegate: AnyObject {
     func consentViewControllerWillDismiss(viewController: UIViewController)
 }
 

--- a/WebAuthnKit/Sources/Client/Client.swift
+++ b/WebAuthnKit/Sources/Client/Client.swift
@@ -16,7 +16,7 @@ public enum ClientOperationType {
    case create
 }
 
-public protocol ClientOperationDelegate: class {
+public protocol ClientOperationDelegate: AnyObject {
     func operationDidFinish(opType: ClientOperationType, opId: String)
 }
 

--- a/WebAuthnKit/Sources/Format/Base64.swift
+++ b/WebAuthnKit/Sources/Format/Base64.swift
@@ -12,7 +12,7 @@ public class Base64 {
     
     
     public static func encodeBase64(_ bytes: [UInt8]) -> String {
-        return encodeBase64(Data(bytes: bytes))
+        return encodeBase64(Data(bytes))
     }
     
     public static func encodeBase64(_ data: Data) -> String {
@@ -20,7 +20,7 @@ public class Base64 {
     }
 
     public static func encodeBase64URL(_ bytes: [UInt8]) -> String {
-        return encodeBase64URL(Data(bytes: bytes))
+        return encodeBase64URL(Data(bytes))
     }
 
     public static func encodeBase64URL(_ data: Data) -> String {

--- a/WebAuthnKit/Sources/Format/Bytes.swift
+++ b/WebAuthnKit/Sources/Format/Bytes.swift
@@ -11,7 +11,7 @@ import Foundation
 public class Bytes {
     
     public static func fromHex(_ value: String) -> [UInt8] {
-        return Data(hex: value).bytes
+        return Data(hex: value).byteArray
     }
     
     public static func fromString(_ value: String) -> [UInt8] {


### PR DESCRIPTION
- https://prex.atlassian.net/browse/PI-7741
- `CryptoSwift` renamed `bytes` to `byteArray` to avoid conflict.
  - `bytes: RawSpan` property added to Swift 6.2. 
- Removed some warnings and updated dependencies.